### PR TITLE
Use Span instead of Anchor when links are disabled/active

### DIFF
--- a/lib/bootstrap_pagination/bootstrap_renderer.rb
+++ b/lib/bootstrap_pagination/bootstrap_renderer.rb
@@ -22,7 +22,7 @@ module BootstrapPagination
 
     def page_number(page)
       if page == current_page
-        tag('li', link(page, page), :class => 'active')
+        tag('li', tag('span', page), :class => 'active')
       else
         tag('li', link(page, page, :rel => rel_value(page)))
       end
@@ -46,7 +46,7 @@ module BootstrapPagination
       if page
         tag('li', link(text, page), :class => classname)
       else
-        tag('li', link(text, '#'), :class => "%s disabled" % classname)
+        tag('li', tag('span', text), :class => "%s disabled" % classname)
       end
     end
   end

--- a/spec/pagination_spec.rb
+++ b/spec/pagination_spec.rb
@@ -67,6 +67,6 @@ describe "Bootstrap Renderer" do
   end
 
   it "has anchors within each list item" do
-    @html.css('ul li').each { |li| li.at_css('a').wont_be_nil }
+    @html.css('ul li').each { |li| li.at_css('a', 'span').wont_be_nil }
   end
 end


### PR DESCRIPTION
The title says it all.

When a link is marked as "disabled" or "active" it shouldn't be clickable. Normally it's not a big deal, but it turned out that it was causing issues with our interface. Luckily Twitter Bootstrap supports styling the Anchor or the Span inside the List Element the same.
