### PR TITLE
require will_paginate

### DIFF
--- a/lib/will_paginate/bootstrap.rb
+++ b/lib/will_paginate/bootstrap.rb
@@ -1,3 +1,5 @@
+require 'will_paginate'
+
 if defined?(ActionView)
   require "bootstrap_pagination/action_view"
 end


### PR DESCRIPTION
When you only add the gem `will_paginate-bootstrap` in the `Gemfile` of a Rails application, `will_paginate` itself won't be required. You have to require it yourself or explicitly add `will_paginate` in the Gemfile. Otherwise you get errors like this:

```
undefined method `paginate' for #<ActiveRecord::Relation::XXX>
```

This patch always requires will_paginate.
