### PR TITLE
hack to make bootstrap 3 compatable

### DIFF
--- a/lib/bootstrap_pagination/bootstrap_renderer.rb
+++ b/lib/bootstrap_pagination/bootstrap_renderer.rb
@@ -15,7 +15,7 @@ module BootstrapPagination
         end
       end
 
-      html_container(tag('ul', list_items.join(@options[:link_separator])))
+      html_container(tag('ul class="pagination"', list_items.join(@options[:link_separator])))
     end
 
     protected


### PR DESCRIPTION
Hi Nickpad,

Greetings from San Francisco.

Big fan of your will_paginate-bootstrap gem!

It wasn't compatible with Bootstrap 3 rc1, but I figured out how to make it so.

In Bootstrap 2:

```
<div class="pagination">
  <ul>
    <li><a href="#">Prev</a></li>
    <li><a href="#">1</a></li>
    <li><a href="#">2</a></li>
    <li><a href="#">3</a></li>
    <li><a href="#">4</a></li>
    <li><a href="#">5</a></li>
    <li><a href="#">Next</a></li>
  </ul>
</div>
```

In Bootstrap 3:

```
<ul class="pagination">
  <li><a href="#">&laquo;</a></li>
  <li><a href="#">1</a></li>
  <li><a href="#">2</a></li>
  <li><a href="#">3</a></li>
  <li><a href="#">4</a></li>
  <li><a href="#">5</a></li>
  <li><a href="#">&raquo;</a></li>
</ul>
```

It's a very subtle difference, and it's kind of annoying they decided to make such an irrelevant change. So my fix was to put the class declaration in the ul tag. I didn't dig deeply enough to remove the now-irrelevant class declaration from the div tag - it doesn't seem to matter, but it should be cleaned up somewhere. 

Thanks and keep making time-saving tools like this!
