### PR TITLE
only require sinatra if actionview isn't defined

### DIFF
--- a/lib/will_paginate/bootstrap.rb
+++ b/lib/will_paginate/bootstrap.rb
@@ -2,8 +2,6 @@ require 'will_paginate'
 
 if defined?(ActionView)
   require "bootstrap_pagination/action_view"
-end
-
-if defined?(Sinatra)
+elsif defined?(Sinatra)
   require "bootstrap_pagination/sinatra"
 end


### PR DESCRIPTION
I'm not sure if others have had this problem, but the gem was failing to load in a rails 4 project because the constant `Sinatra` was defined (I didn't look where). I don't know if there's ever a case where you'd want to require both the action_view and sinatra files, so I just switched it to require sinatra only if `ActionView` isn't defined.
