### PR TITLE
Put ellipsis into span

### DIFF
--- a/lib/bootstrap_pagination/bootstrap_renderer.rb
+++ b/lib/bootstrap_pagination/bootstrap_renderer.rb
@@ -45,7 +45,7 @@ module BootstrapPagination
     end
 
     def gap
-      tag("li", link(ELLIPSIS, "#"), class: "disabled")
+      tag("li", tag("span", ELLIPSIS), class: "disabled")
     end
 
     def previous_page

--- a/spec/pagination_spec.rb
+++ b/spec/pagination_spec.rb
@@ -65,12 +65,31 @@ describe "Bootstrap Renderer" do
     html.css('[rel~=next]').size.must_equal 2
   end
 
-  it "has an anchor within each non-active list item" do
-    html.css('ul li:not(.active)').each { |li| li.at_css('a').wont_be_nil }
+  it "has an anchor within each non-active/non-disabled list item" do
+    html.css('ul li:not(.active):not(.disabled)').each { |li| li.at_css('a').wont_be_nil }
   end
 
   it "uses a span element for the active page" do
     html.at_css('ul li.active span').wont_be_nil
+  end
+
+  it 'uses a span to wrap the ellipsis' do
+    ellipsis = BootstrapPagination::BootstrapRenderer::ELLIPSIS
+    html.at_css('li.disabled span', text: ellipsis).wont_be_nil
+  end
+
+  describe 'when on the first lage' do
+    let(:page) { 1 }
+    it 'uses a span element for the (disabled) previous button' do
+      html.at_css('li.disabled span', text: 'Previous Label').wont_be_nil
+    end
+  end
+
+  describe 'when on the last lage' do
+    let(:page) { collection_size }
+    it 'uses a span element for the (disabled) next button' do
+      html.at_css('li.disabled span', text: 'Next Label').wont_be_nil
+    end
   end
 
   it "has no outer pagination div" do


### PR DESCRIPTION
When the ellipsis is contained inside a link that points to `#`, clicking it scrolls to the beginning of the page which confuses users. ;)

This makes it use a `span` instead.

Also adds tests for disabled prev/next buttons at first/last page.
