### PR TITLE
Ensure pagination list is wrapped in a div.

### DIFF
--- a/lib/bootstrap_pagination/bootstrap_renderer.rb
+++ b/lib/bootstrap_pagination/bootstrap_renderer.rb
@@ -15,7 +15,7 @@ module BootstrapPagination
         end
       end.join(@options[:link_separator])
 
-      tag("ul", list_items, class: ul_class)
+      tag("div", tag("ul", list_items), class: ul_class)
     end
 
     def container_attributes


### PR DESCRIPTION
I'm actually not sure how this gem worked prior - but Bootstrap specs
require that the pagination list is wrapped in a div, which has the
correct class applied to it.

Gem wasn't working for me without this - simply showed up as an unstyled
list.
