### PR TITLE
Fixes ActionView::Template::Error: uninitialized constant ActionView::CompiledTemplates::BootstrapPagination

### DIFF
--- a/lib/bootstrap_pagination/action_view.rb
+++ b/lib/bootstrap_pagination/action_view.rb
@@ -4,6 +4,6 @@ require "bootstrap_pagination/bootstrap_renderer"
 module BootstrapPagination
   # A custom renderer class for WillPaginate that produces markup suitable for use with Twitter Bootstrap.
   class Rails < WillPaginate::ActionView::LinkRenderer
-    include BootstrapRenderer
+    include BootstrapPagination::BootstrapRenderer
   end
 end


### PR DESCRIPTION
During development I noticed that in newer Ruby versions (I'm running ruby 2.2.3p173) I was getting the following error when using will_paginate-bootstrap:
`ActionView::Template::Error: uninitialized constant ActionView::CompiledTemplates::BootstrapPagination`

After some debugging I found out that the include didn't seem to work properly when loading the Rails version of the gem. I fixed this by implicitly defining which `BootstrapRenderer` to include.