### PR TITLE
Make bootstrap rails renderer default for rails app

### DIFF
--- a/lib/bootstrap_pagination/action_view.rb
+++ b/lib/bootstrap_pagination/action_view.rb
@@ -1,3 +1,4 @@
+require "will_paginate/action_view"
 require "will_paginate/view_helpers/action_view"
 require "bootstrap_pagination/bootstrap_renderer"
 

--- a/lib/will_paginate/action_view.rb
+++ b/lib/will_paginate/action_view.rb
@@ -1,0 +1,10 @@
+require 'will_paginate/view_helpers/action_view'
+
+module WillPaginate
+  module ActionView
+    def will_paginate(collection = nil, options = {})
+      options[:renderer] ||= BootstrapPagination::Rails
+      super.try :html_safe
+    end
+  end
+end


### PR DESCRIPTION
## What's this PR do? 
when you use this gem with rails, it requires will_paginate call with renderer option
```
<%= will_paginate @collection, renderer: BootstrapPagination::Rails %>
```
This PR avoids explicit renderer option, you can simply call `will_paginate` without option on your rails app
```
<%= will_paginate @collection %>
```