### PR TITLE
Fix deprecation warnings for Ruby 2.4

### DIFF
--- a/lib/bootstrap_pagination/bootstrap_renderer.rb
+++ b/lib/bootstrap_pagination/bootstrap_renderer.rb
@@ -8,7 +8,7 @@ module BootstrapPagination
     def to_html
       list_items = pagination.map do |item|
         case item
-          when Fixnum
+          when 0.class
             page_number(item)
           else
             send(item)


### PR DESCRIPTION
Since 2.4 deprecate the use of constant `Fixnum`, now check for `0.class` instead (to ensure compatibility with older versions).

Cheers.